### PR TITLE
Add Send to Offscreen in console.rs so Offscreen

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -128,6 +128,10 @@ impl Offscreen {
 
 }
 
+// ! libtcod is not thread-safe, this may have some side effects but none have been seen yet
+// ! This is primary so that Offscreen consoles can be used as specs resources
+unsafe impl Send for Offscreen {}
+
 /// The console representing the main window of the application
 ///
 /// This is the only console type capable of handling user input and flushing its contents onto the screen.


### PR DESCRIPTION
Specs requires resources to implement Send at a minimum.  This change allows specs to use Offscreen consoles are resources.  LibTCOD itself is not threadsafe, and this might have some unwanted side effects, but none have been discovered yet.